### PR TITLE
Improve validator

### DIFF
--- a/lib/rails-nl2sql.rb
+++ b/lib/rails-nl2sql.rb
@@ -1,1 +1,2 @@
 require "rails/nl2sql"
+

--- a/lib/rails/nl2sql/query_validator.rb
+++ b/lib/rails/nl2sql/query_validator.rb
@@ -15,9 +15,16 @@ module Rails
         # Basic validation: prevent destructive commands
         disallowed_keywords = %w(DROP DELETE UPDATE INSERT TRUNCATE ALTER CREATE EXEC EXECUTE MERGE REPLACE)
         query_upper = query.upcase
-        
+
         if disallowed_keywords.any? { |keyword| query_upper.include?(keyword) }
           raise Rails::Nl2sql::Error, "Query contains disallowed keywords."
+        end
+
+        # Ensure there is only a single statement
+        cleaned_query = query.rstrip
+        cleaned_query = cleaned_query.chomp(';')
+        if cleaned_query.include?(';')
+          raise Rails::Nl2sql::Error, "Query contains multiple statements."
         end
 
         # Ensure it's a SELECT query

--- a/rails-nl2sql.gemspec
+++ b/rails-nl2sql.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "openai", "~> 0.3"
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec-rails", "~> 6.0"
   spec.add_dependency "railties", ">= 6.0"

--- a/spec/lib/rails/nl2sql/query_validator_spec.rb
+++ b/spec/lib/rails/nl2sql/query_validator_spec.rb
@@ -50,5 +50,11 @@ RSpec.describe Rails::Nl2sql::QueryValidator do
       allow(connection).to receive(:execute).and_raise(ActiveRecord::StatementInvalid.new("Syntax error"))
       expect { described_class.validate("SELECT FROM users") }.to raise_error("Invalid SQL query: Syntax error")
     end
+
+    it 'raises an error when multiple statements are provided' do
+      allow(connection).to receive(:execute).with("EXPLAIN SELECT * FROM users").and_return(true)
+      multi_query = "SELECT * FROM users; SELECT * FROM products"
+      expect { described_class.validate(multi_query) }.to raise_error("Query contains multiple statements.")
+    end
   end
 end


### PR DESCRIPTION
## Summary
- allow modern Bundler versions
- guard against SQL with multiple statements
- test new validation rule
- ensure top-level require has newline

## Testing
- `bundle exec rake spec` *(fails: Could not find rake-10.5.0, rspec-rails-6.1.5, openai-0.3.0, railties-6.1.4.7, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68794fc487ac8332bd1645b3005987ba