### PR TITLE
Add ActiveRecord from_nl support and schema caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ To execute a natural language query, you can use the `execute` method:
 results = Rails::Nl2sql::Processor.execute("Show me all the users from California")
 ```
 
+### Using `from_nl` with ActiveRecord
+
+You can call the NL2SQL processor directly on your models. The `from_nl` method
+returns an `ActiveRecord::Relation` so you can chain scopes, pagination and
+other query modifiers as usual.
+
+```ruby
+User.from_nl("all users who signed up last week").limit(10)
+```
+
 You can also specify which tables to include or exclude:
 
 ```ruby
@@ -58,6 +68,18 @@ Rails::Nl2sql::Processor.get_tables
 
 ```ruby
 Rails::Nl2sql::Processor.get_schema(include: ["users", "orders"])
+```
+
+### Schema caching
+
+For efficiency the gem caches the full database schema on first use. The cached
+schema is reused for subsequent requests so your application doesn't need to hit
+the database every time a prompt is generated.
+
+You can clear the cached schema if your database changes:
+
+```ruby
+Rails::Nl2sql::SchemaBuilder.clear_cache!
 ```
 
 ## Development

--- a/lib/rails/nl2sql.rb
+++ b/lib/rails/nl2sql.rb
@@ -2,6 +2,7 @@ require "rails/nl2sql/version"
 require "rails/nl2sql/query_generator"
 require "rails/nl2sql/schema_builder"
 require "rails/nl2sql/query_validator"
+require "rails/nl2sql/active_record_extension"
 require "rails/nl2sql/railtie" if defined?(Rails)
 
 module Rails

--- a/lib/rails/nl2sql/active_record_extension.rb
+++ b/lib/rails/nl2sql/active_record_extension.rb
@@ -1,0 +1,21 @@
+require 'active_support/concern'
+require 'active_support/lazy_load_hooks'
+
+module Rails
+  module Nl2sql
+    module ActiveRecordExtension
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def from_nl(prompt, options = {})
+          sql = Rails::Nl2sql::Processor.generate_query_only(prompt, options)
+          from(Arel.sql("(#{sql}) AS #{table_name}"))
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  include Rails::Nl2sql::ActiveRecordExtension
+end

--- a/lib/rails/nl2sql/schema_builder.rb
+++ b/lib/rails/nl2sql/schema_builder.rb
@@ -1,11 +1,24 @@
 module Rails
   module Nl2sql
     class SchemaBuilder
+      @@schema_cache = nil
+
       def self.build_schema(options = {})
+        if options.empty? && @@schema_cache
+          return @@schema_cache
+        end
+
         tables = get_filtered_tables(options)
-        
+
         schema_text = build_schema_text(tables)
+
+        @@schema_cache = schema_text if options.empty?
+
         schema_text
+      end
+
+      def self.clear_cache!
+        @@schema_cache = nil
       end
 
       def self.get_database_type

--- a/spec/lib/rails/nl2sql/active_record_extension_spec.rb
+++ b/spec/lib/rails/nl2sql/active_record_extension_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'rails/nl2sql'
+
+# Minimal mock ActiveRecord setup
+module ActiveRecord
+  class Base
+    def self.connection
+      @@connection
+    end
+
+    def self.connection=(conn)
+      @@connection = conn
+    end
+
+    def self.from(sql)
+      ActiveRecord::Relation.new
+    end
+  end
+
+  class Relation
+  end
+end
+
+class User < ActiveRecord::Base; end
+
+RSpec.describe Rails::Nl2sql::ActiveRecordExtension do
+  let(:connection) { double('ActiveRecord::ConnectionAdapters::AbstractAdapter', adapter_name: 'PostgreSQL') }
+
+  before do
+    ActiveRecord::Base.connection = connection
+    allow(connection).to receive(:tables).and_return(['users'])
+    allow(connection).to receive(:columns).with('users').and_return([double('column', name: 'id'), double('column', name: 'name')])
+
+    Rails::Nl2sql.api_key = 'test'
+    Rails::Nl2sql.model = 'text-davinci-003'
+  end
+
+  it 'returns an ActiveRecord::Relation from natural language' do
+    allow(Rails::Nl2sql::Processor).to receive(:generate_query_only).with('all users', {}).and_return('SELECT * FROM users')
+    relation = User.from_nl('all users')
+    expect(relation).to be_a(ActiveRecord::Relation)
+  end
+end

--- a/spec/lib/rails/nl2sql/schema_caching_spec.rb
+++ b/spec/lib/rails/nl2sql/schema_caching_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'rails/nl2sql/schema_builder'
+
+module ActiveRecord
+  class Base
+    def self.connection
+      @@connection
+    end
+
+    def self.connection=(conn)
+      @@connection = conn
+    end
+  end
+end
+
+RSpec.describe Rails::Nl2sql::SchemaBuilder do
+  let(:connection) { double('ActiveRecord::ConnectionAdapters::AbstractAdapter', adapter_name: 'PostgreSQL') }
+  let(:columns) { [double('column', name: 'id'), double('column', name: 'name')] }
+
+  before do
+    ActiveRecord::Base.connection = connection
+    allow(connection).to receive(:tables).and_return(['users'])
+    allow(connection).to receive(:columns).with('users').and_return(columns)
+    described_class.clear_cache!
+  end
+
+  it 'caches the schema after first build' do
+    described_class.build_schema
+    described_class.build_schema
+    expect(connection).to have_received(:columns).with('users').once
+  end
+end


### PR DESCRIPTION
## Summary
- add `ActiveRecordExtension` with `from_nl` relation method
- cache schema introspection results and expose `clear_cache!`
- document ActiveRecord usage and schema caching
- test ActiveRecord integration and caching behaviour
- refine ActiveRecord extension loading and docs

## Testing
- `bundle exec rspec` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68795c1621848332ac2b8ec47bf7961e