### PR TITLE
Fix prompt template ERB rendering

### DIFF
--- a/lib/rails/nl2sql.rb
+++ b/lib/rails/nl2sql.rb
@@ -39,10 +39,9 @@ module Rails
     end
 
     def self.prompt_template
-      @prompt_template ||= begin
-        erb = ERB.new(File.read(prompt_template_path))
-        YAML.safe_load(erb.result)
-      end
+      # Load the YAML template without evaluating ERB so we can
+      # interpolate variables later when building prompts.
+      @prompt_template ||= YAML.safe_load(File.read(prompt_template_path))
     end
 
     class Processor


### PR DESCRIPTION
## Summary
- do not evaluate ERB when loading the YAML prompt template

## Testing
- `bundle exec rspec` *(fails: bundler not installed due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_687a5ae99a5483328389b39ade6f40fd