### PR TITLE
Fix from_nl trailing semicolon

### DIFF
--- a/lib/rails/nl2sql/active_record_extension.rb
+++ b/lib/rails/nl2sql/active_record_extension.rb
@@ -9,6 +9,8 @@ module Rails
       class_methods do
         def from_nl(prompt, options = {})
           sql = Rails::Nl2sql::Processor.generate_query_only(prompt, options)
+          sql = sql.to_s.strip
+          sql = sql.chomp(';')
           from(Arel.sql("(#{sql}) AS #{table_name}"))
         end
       end

--- a/spec/lib/rails/nl2sql/active_record_extension_spec.rb
+++ b/spec/lib/rails/nl2sql/active_record_extension_spec.rb
@@ -40,4 +40,10 @@ RSpec.describe Rails::Nl2sql::ActiveRecordExtension do
     relation = User.from_nl('all users')
     expect(relation).to be_a(ActiveRecord::Relation)
   end
+
+  it 'strips a trailing semicolon from the generated query' do
+    allow(Rails::Nl2sql::Processor).to receive(:generate_query_only).with('all users', {}).and_return('SELECT * FROM users;')
+    expect(User).to receive(:from).with(Arel.sql('(SELECT * FROM users) AS users')).and_call_original
+    User.from_nl('all users')
+  end
 end


### PR DESCRIPTION
## Summary
- ensure `from_nl` strips trailing semicolons before embedding
- test that `from_nl` removes the trailing semicolon

## Testing
- `bundle exec rspec` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5d43e8e88332ba0c90b1d8fdf5a7